### PR TITLE
feat: option to open terminal at current note's folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-open-in-terminal",
-  "version": "0.6.1",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-open-in-terminal",
-      "version": "0.6.1",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.1",

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -8,6 +8,7 @@ import { logger } from './logger';
 
 export type LaunchCommand = {
   command: string;
+  cwd?: string;
   cleanup?: () => void;
 };
 
@@ -213,7 +214,7 @@ const buildWindowsLaunch = (
   return { command };
 };
 
-const buildUnixLaunch = (terminalApp: string, toolCommand?: string): LaunchCommand | null => {
+const buildUnixLaunch = (terminalApp: string, vaultPath: string, toolCommand?: string): LaunchCommand | null => {
   const app = sanitizeTerminalApp(terminalApp);
   if (!app) {
     return null;
@@ -221,27 +222,27 @@ const buildUnixLaunch = (terminalApp: string, toolCommand?: string): LaunchComma
 
   if (!toolCommand) {
     const command = `${app}`;
-    logger.log('Unix launch (simple)', { command });
-    return { command };
+    logger.log('Unix launch (simple)', { command, vaultPath });
+    return { command, cwd: vaultPath };
   }
 
   const shellCommand = `cd "$PWD"; ${toolCommand}; exec "$SHELL"`;
 
   if (app.includes('gnome-terminal')) {
     const command = `${app} -- bash -lc "${shellCommand}"`;
-    logger.log('Unix launch (gnome-terminal)', { command, toolCommand });
-    return { command };
+    logger.log('Unix launch (gnome-terminal)', { command, toolCommand, vaultPath });
+    return { command, cwd: vaultPath };
   }
 
   if (app.includes('konsole')) {
     const command = `${app} -e bash -lc "${shellCommand}"`;
-    logger.log('Unix launch (konsole)', { command, toolCommand });
-    return { command };
+    logger.log('Unix launch (konsole)', { command, toolCommand, vaultPath });
+    return { command, cwd: vaultPath };
   }
 
   const command = `${app} -e bash -lc "${shellCommand}"`;
-  logger.log('Unix launch (generic tool)', { command, toolCommand });
-  return { command };
+  logger.log('Unix launch (generic tool)', { command, toolCommand, vaultPath });
+  return { command, cwd: vaultPath };
 };
 
 export const buildLaunchCommand = (
@@ -259,5 +260,5 @@ export const buildLaunchCommand = (
   if (Platform.isWin) {
     return buildWindowsLaunch(terminalApp, vaultPath, toolCommand, options?.useWslOnWindows);
   }
-  return buildUnixLaunch(terminalApp, toolCommand);
+  return buildUnixLaunch(terminalApp, vaultPath, toolCommand);
 };

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -89,7 +89,7 @@ const buildMacLaunch = (
     const escapedPath = escapeDoubleQuotes(vaultPath);
     const command = `open -a "${escapedApp}" "${escapedPath}"`;
     logger.log('macOS simple launch', { app, command, vaultPath });
-    return { command };
+    return { command, cwd: vaultPath };
   }
 
   const escapedVaultPath = escapeDoubleQuotes(vaultPath);
@@ -101,7 +101,7 @@ const buildMacLaunch = (
   const { path, cleanup } = ensureTempScript(scriptLines.join('\n'));
   const command = `open -a "${escapeDoubleQuotes(app)}" "${path}"`;
   logger.log('macOS script launch', { app, command, script: path, toolCommand });
-  return { command, cleanup };
+  return { command, cwd: vaultPath, cleanup };
 };
 
 const buildWindowsLaunch = (
@@ -134,7 +134,7 @@ const buildWindowsLaunch = (
     if (lowerApp === 'cmd.exe' || lowerApp === 'cmd') {
       const command = `start "" cmd.exe /K "${wslCommand}"`;
       logger.log('Windows launch (cmd.exe + WSL)', { command, toolCommand, vaultPath, wslVaultPath });
-      return { command };
+      return { command, cwd: vaultPath };
     }
 
     if (lowerApp === 'powershell' || lowerApp === 'powershell.exe') {
@@ -148,7 +148,7 @@ const buildWindowsLaunch = (
         vaultPath,
         wslVaultPath
       });
-      return { command: psCommand };
+      return { command: psCommand, cwd: vaultPath };
     }
 
     if (lowerApp === 'wt.exe' || lowerApp === 'wt') {
@@ -156,7 +156,7 @@ const buildWindowsLaunch = (
         ? `start "" wt.exe new-tab wsl.exe --cd "${escapeForCmdQuotedString(wslVaultPath)}" ${toolCommand}`
         : `start "" wt.exe new-tab wsl.exe --cd "${escapeForCmdQuotedString(wslVaultPath)}"`;
       logger.log('Windows launch (wt + WSL)', { command, toolCommand, vaultPath, wslVaultPath });
-      return { command };
+      return { command, cwd: vaultPath };
     }
 
     const command = `start "" cmd.exe /K "${wslCommand}"`;
@@ -167,7 +167,7 @@ const buildWindowsLaunch = (
       vaultPath,
       wslVaultPath
     });
-    return { command };
+    return { command, cwd: vaultPath };
   }
 
   if (lowerApp === 'cmd.exe' || lowerApp === 'cmd') {
@@ -175,7 +175,7 @@ const buildWindowsLaunch = (
       ? `start "" cmd.exe /K "${cdCommand}${tool}"`
       : `start "" cmd.exe /K "${cdCommand}"`;
     logger.log('Windows launch (cmd.exe)', { command, toolCommand, vaultPath });
-    return { command };
+    return { command, cwd: vaultPath };
   }
 
   if (lowerApp === 'powershell' || lowerApp === 'powershell.exe') {
@@ -185,14 +185,14 @@ const buildWindowsLaunch = (
         "''"
       )}';"`;
       logger.log('Windows launch (powershell)', { command, toolCommand, vaultPath });
-      return { command };
+      return { command, cwd: vaultPath };
     }
     const command = `start "" powershell -NoExit -Command "Set-Location '${vaultPath.replace(
       /'/g,
       "''"
     )}'; ${toolCommand}"`;
     logger.log('Windows launch (powershell tool)', { command, toolCommand, vaultPath });
-    return { command };
+    return { command, cwd: vaultPath };
   }
 
   if (lowerApp === 'wt.exe' || lowerApp === 'wt') {
@@ -200,18 +200,18 @@ const buildWindowsLaunch = (
       ? `start "" wt.exe new-tab cmd /K "${cdCommand}${tool}"`
       : `start "" wt.exe new-tab cmd /K "${cdCommand}"`;
     logger.log('Windows launch (wt)', { command, toolCommand, vaultPath });
-    return { command };
+    return { command, cwd: vaultPath };
   }
 
   if (!toolCommand) {
     const command = `start "" "${app}"`;
     logger.log('Windows launch (generic simple)', { command, vaultPath });
-    return { command };
+    return { command, cwd: vaultPath };
   }
 
   const command = `start "" cmd.exe /K "${cdCommand}${tool}"`;
   logger.log('Windows launch (generic tool fallback)', { command, app, toolCommand, vaultPath });
-  return { command };
+  return { command, cwd: vaultPath };
 };
 
 const buildUnixLaunch = (terminalApp: string, vaultPath: string, toolCommand?: string): LaunchCommand | null => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import { join } from 'path';
 
 import { FileSystemAdapter, Notice, Platform, Plugin } from 'obsidian';
 
@@ -72,8 +73,17 @@ export default class OpenInTerminalPlugin extends Plugin {
       return null;
     }
     const vaultPath = adapter.getBasePath();
+
+    let workingPath = vaultPath;
+    if (this.settings.openAtNoteFolderEnabled) {
+      const activeFile = this.app.workspace.getActiveFile();
+      if (activeFile && activeFile.parent) {
+        workingPath = join(vaultPath, activeFile.parent.path);
+      }
+    }
+
     const terminalApp = getCurrentTerminalApp(this.settings.terminalApp);
-    const launchCommand = buildLaunchCommand(terminalApp, vaultPath, toolCommand, {
+    const launchCommand = buildLaunchCommand(terminalApp, workingPath, toolCommand, {
       useWslOnWindows: this.settings.enableWslOnWindows
     });
     logger.log('Compose launch command', {
@@ -81,6 +91,7 @@ export default class OpenInTerminalPlugin extends Plugin {
       terminalApp,
       toolCommand,
       vaultPath,
+      workingPath,
       launchCommand
     });
     return launchCommand;
@@ -109,7 +120,7 @@ export default class OpenInTerminalPlugin extends Plugin {
     try {
       logger.log('Spawning command', { label, command: launchCommand.command, vaultPath });
       const child = spawn(launchCommand.command, {
-        cwd: vaultPath,
+        cwd: launchCommand.cwd ?? vaultPath,
         shell: true,
         detached: true,
         stdio: 'ignore'

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,7 +67,7 @@ export default class OpenInTerminalPlugin extends Plugin {
     }
   }
 
-  private composeLaunchCommand(toolCommand?: string): LaunchCommand | null {
+  private composeLaunchCommand(toolCommand?: string, useVaultRoot = false): LaunchCommand | null {
     const adapter = this.app.vault.adapter;
     if (!(adapter instanceof FileSystemAdapter)) {
       return null;
@@ -75,7 +75,7 @@ export default class OpenInTerminalPlugin extends Plugin {
     const vaultPath = adapter.getBasePath();
 
     let workingPath = vaultPath;
-    if (this.settings.openAtNoteFolderEnabled) {
+    if (!useVaultRoot && this.settings.openAtNoteFolderEnabled) {
       const activeFile = this.app.workspace.getActiveFile();
       if (activeFile && activeFile.parent) {
         workingPath = join(vaultPath, activeFile.parent.path);
@@ -165,7 +165,7 @@ export default class OpenInTerminalPlugin extends Plugin {
     }
 
     const gitCommand = this.buildGitCommitPushCommand();
-    this.runLaunchCommand(() => this.composeLaunchCommand(gitCommand), 'Git: commit and push');
+    this.runLaunchCommand(() => this.composeLaunchCommand(gitCommand, true), 'Git: commit and push');
   }
 
   private async runGitPull() {
@@ -175,7 +175,7 @@ export default class OpenInTerminalPlugin extends Plugin {
       return;
     }
 
-    this.runLaunchCommand(() => this.composeLaunchCommand('git pull'), 'Git: pull');
+    this.runLaunchCommand(() => this.composeLaunchCommand('git pull', true), 'Git: pull');
   }
 
   private async checkGitRepo(): Promise<boolean> {

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -45,6 +45,20 @@ export class OpenInTerminalSettingTab extends PluginSettingTab {
           })
       );
 
+    new Setting(containerEl)
+      .setName('Open at current note\'s folder')
+      .setDesc(
+        'When enabled, the terminal opens at the folder of the currently active note instead of the vault root. Falls back to vault root if no note is open.'
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.openAtNoteFolderEnabled)
+          .onChange(async (value) => {
+            this.plugin.settings.openAtNoteFolderEnabled = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
     if (Platform.isWin) {
       new Setting(containerEl)
         .setName('Use WSL for commands')

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -19,6 +19,7 @@ export interface OpenInTerminalSettings {
   enableGitCommitPush: boolean;
   enableGitPull: boolean;
   defaultCommitMessage: string;
+  openAtNoteFolderEnabled: boolean;
 }
 
 export const defaultTerminalApp = (): string => {
@@ -72,7 +73,8 @@ export const DEFAULT_SETTINGS: OpenInTerminalSettings = {
   enableWslOnWindows: false,
   enableGitCommitPush: false,
   enableGitPull: false,
-  defaultCommitMessage: 'update'
+  defaultCommitMessage: 'update',
+  openAtNoteFolderEnabled: false
 };
 
 type UnknownRecord = Record<string, unknown>;
@@ -133,7 +135,11 @@ export const normalizeSettings = (stored: unknown): OpenInTerminalSettings => {
     defaultCommitMessage:
       typeof source.defaultCommitMessage === 'string'
         ? source.defaultCommitMessage
-        : DEFAULT_SETTINGS.defaultCommitMessage
+        : DEFAULT_SETTINGS.defaultCommitMessage,
+    openAtNoteFolderEnabled: readBoolean(
+      source.openAtNoteFolderEnabled,
+      DEFAULT_SETTINGS.openAtNoteFolderEnabled
+    )
   };
 };
 


### PR DESCRIPTION
## Summary

- Add a toggle in Settings -> Open in Terminal: **"Open at current note's folder"** (default: off)
- When enabled, all terminal/CLI launches use the active note's parent directory as working directory
- Falls back to vault root if no note is currently open
- Git commands (commit & push, pull) always use vault root regardless of this setting

## Motivation

When working on notes nested in subdirectories (e.g. `Projects/MyProject/note.md`), opening a terminal scoped to `Projects/MyProject/` is more useful than vault root, especially when using CLI tools like Claude Code, Codex, or Gemini that infer project context from the working directory.

## Changes

- `settings.ts` -- add `openAtNoteFolderEnabled: boolean` (default `false`)
- `settings-tab.ts` -- add toggle under "Terminal integration"
- `main.ts` -- resolve working path in `composeLaunchCommand`; git callers opt out via `useVaultRoot`
- `launcher.ts` -- `buildUnixLaunch` now accepts and uses path; `LaunchCommand` gains `cwd` field; all platform builders set it

## Test plan
- [x] Toggle off (default): terminal opens at vault root
- [x] Toggle on, note open in subdirectory: terminal opens at note's folder
- [x] Toggle on, no note open: terminal falls back to vault root
- [x] Git commit/push and pull: always run at vault root regardless of toggle
- [x] Note at vault root: terminal opens at vault root, no path error
- [x] Path with spaces: terminal opens correctly
- [x] Deeply nested note: terminal opens at the note's direct parent, not an ancestor
- [x] Switch active note: terminal uses the newly active note's folder
- [x] No active tab: terminal falls back to vault root

Closes #8